### PR TITLE
Fix closing ephemeral interfaces when dependent block is destroyed

### DIFF
--- a/blocks/technical/functional.js
+++ b/blocks/technical/functional.js
@@ -85,7 +85,7 @@ Blocks.crafting_table = class extends Planks{
 	static breaktime = 3
 	drops(){ return new Items.crafting_table(1) }
 	interact(_, player){
-		player.openInterface(new CraftingInterface, 0)
+		player.openInterface(new CraftingInterface, 0, this)
 		return 0
 	}
 }

--- a/entities/entity.js
+++ b/entities/entity.js
@@ -140,7 +140,7 @@ export class Entity{
 			e.sock = this.sock
 		}else throw '.openInterface(<here>, _): Block, entity or ephemeral interface expected'
 		this.sock.interface = e
-		this.sock.interfaceD = e.isBlock ? save(e) : e instanceof Entity ? e : null
+		this.sock.interfaceD = dep.isBlock ? save(dep) : dep instanceof Entity ? dep : null
 		this.sock.send(res.build())
 		e.interfaceOpened?.(id, this)
 		return true


### PR DESCRIPTION
Fixes the bug where when you're crafting and the crafting table is destroyed, the crafting UI still remains. Also I did not spend two hours trying to figure out if this was server or client, what on earth the D in interfaceD means, and how tf the whole interface system works